### PR TITLE
feat: extend support for multiple repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 ## Key Features
 - **Effortless Configuration:** GitSquid provides a visual interface that allows you to easily configure and update your personal token and monitored repository. No more hassle with manual setups – everything is streamlined for convenience from the first time you open the application.
 
-- **Advanced Encryption:** Your privacy is a top priority and that's why GitSquid uses AES-256 symmetric encryption to securely persist all your personal data and browsing history, ensuring that your sensitive information remains safe, both during usage and after.
+- **Multiple repositories support:** GitSquid empowers you to effortlessly track and manage issues across multiple GitHub repositories, all in one intuitive platform. Stay organized and enhance productivity with real-time monitoring and updates..
+
+- **Advanced Encryption:** Your privacy is a top priority and that's why GitSquid uses AES-256 symmetric encryption to securely persist all your personal data, ensuring that your sensitive information remains safe, both during usage and after.
 
 - **Responsive data fetching** GitSquid keeps track of your viewing progress and will fetch additional content whenever available as you scroll the issues list. Moreover, you can ping the GitHub services anytime to also fetch the latest issues created during your session.
 
@@ -76,9 +78,7 @@ Here's a look at the upcoming enhancements and fixes planned for GitSquid to ens
 
 - **Adding End-to-End (E2E) Tests:** To further enhance the reliability of GitSquid, there is a plan to introduce E2E tests to simulate real user interactions. This will allow catching issues before they impact users and ensure a seamless experience.
 
-- **Improving Text Rendering with Markdown:** We’re working on enhancing the text rendering mechanism to expand options and peventr reading issues when content exceeds the viewport. This will improve the readability and presentation of formatted text, offering a smoother experience for users working with markdown in their repositories.
-
-- **Fixing Data Fetching Bug for Paginated Issues:** There is a bug identified where, under certain conditions, additional paginated issues are not fetched correctly. This fix will ensure that all relevant data loads without interruption, improving user efficiency.
+- **Improving Text Rendering with Markdown:** We’re working on enhancing the text rendering mechanism to expand options and prevent reading issues when content exceeds the viewport. This will improve the readability and presentation of formatted text, offering a smoother experience for users working with markdown in their repositories.
 
 These updates are part of GitSquid's strategy and ongoing commitment to delivering a robust and user-friendly issue monitoring tool.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,7 +35,7 @@ function createWindow(): void {
 
     // Validates config update requests based on whether the new config is honored by GitHub
     configManager.onConfigurationUpdateRequest((configuration) => {
-      return dataManager.fetchIssues(configuration)
+      return dataManager.fetchIssues(configuration, true)
     })
   })
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,6 @@
 import { electronAPI } from '@electron-toolkit/preload'
 import { contextBridge, ipcRenderer, type IpcRenderer } from 'electron'
-import { type Configuration, type GitSquidAPI, type Issues, MessageType } from './types'
+import { type Configuration, type GitSquidAPI, type IssuesMap, MessageType } from './types'
 
 // Custom APIs for renderer
 const gitSquidAPI: GitSquidAPI = {
@@ -11,8 +11,8 @@ const gitSquidAPI: GitSquidAPI = {
 
   fetchIssues: (refresh?: boolean): Promise<{ success: boolean; error?: unknown }> =>
     ipcRenderer.invoke(MessageType.FetchIssues, refresh),
-  onIssues: (callback: (data: Issues) => void): IpcRenderer =>
-    ipcRenderer.on(MessageType.Issues, (_, data: Issues) => callback(data)),
+  onIssues: (callback: (issuesMap: IssuesMap) => void): IpcRenderer =>
+    ipcRenderer.on(MessageType.Issues, (_, issuesMap: IssuesMap) => callback(issuesMap)),
   readIssue: (issueId: string): Promise<void> => ipcRenderer.invoke(MessageType.ReadIssue, issueId)
 }
 

--- a/src/preload/types.ts
+++ b/src/preload/types.ts
@@ -66,13 +66,39 @@ export type Issue = {
   isLocked: boolean
   body: string
   labels?: string[]
-  read?: boolean
+  read: boolean
+  isPullRequest: boolean
 }
 
 /**
  * The {@link Issues} type represents an array of {@link Issue} instance objects.
  */
 export type Issues = Issue[]
+
+/**
+ * The global issues graph exchanged between main and renderer
+ */
+export type IssuesMap = {
+  /**
+   * URL of a given public GitHub repository.
+   */
+  [url: string]:
+    | {
+        /**
+         * Issues collection.
+         */
+        issues?: Issues
+        /**
+         * Date of last fetch request.
+         */
+        lastRead?: Date
+        /**
+         * Signals whether the successive fetch requests have reached the end of the recordset.
+         */
+        isComplete?: boolean
+      }
+    | undefined
+}
 
 /**
  * The shared interface exposed to Renderer.
@@ -82,6 +108,6 @@ export interface GitSquidAPI {
   onConfiguration: (callback: (configuration: Configuration) => void) => void
 
   fetchIssues: (refresh?: boolean) => Promise<{ success: boolean; error?: unknown }>
-  onIssues: (callback: (issues: Issues) => void) => void
+  onIssues: (callback: (issuesMap: IssuesMap) => void) => void
   readIssue: (issueId: string) => Promise<void>
 }

--- a/src/renderer/src/components/Settings/SettingsForm.tsx
+++ b/src/renderer/src/components/Settings/SettingsForm.tsx
@@ -1,3 +1,4 @@
+import { isValidToken, isValidURL, parseURL } from '@renderer/helpers'
 import { useConfiguration } from '@renderer/providers/configuration'
 import { useRouter } from '@renderer/providers/router'
 import { Anchor } from '@twilio-paste/core/anchor'
@@ -12,7 +13,7 @@ import { Paragraph } from '@twilio-paste/core/paragraph'
 import { Stack } from '@twilio-paste/core/stack'
 import { HideIcon } from '@twilio-paste/icons/esm/HideIcon'
 import { ShowIcon } from '@twilio-paste/icons/esm/ShowIcon'
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
 function SettingsForm(): JSX.Element {
   const { navigate } = useRouter()
@@ -24,14 +25,10 @@ function SettingsForm(): JSX.Element {
   const [urlError, setURLError] = useState(false)
   const [hasServerError, setServerError] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const tokenRegexRef = useRef(
-    new RegExp(/^(gh[pous]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{22,38})$/)
-  )
-  const urlRegexRef = useRef(/^https:\/\/github\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\/?$/)
 
   const submitHandler = (): void => {
-    const tokenIsValid = tokenRegexRef.current.test(token)
-    const urlIsValid = urlRegexRef.current.test(url)
+    const tokenIsValid = isValidToken(token)
+    const urlIsValid = isValidURL(url)
     setTokenError(!tokenIsValid)
     setURLError(!urlIsValid)
 
@@ -44,7 +41,7 @@ function SettingsForm(): JSX.Element {
     setIsLoading(true)
 
     try {
-      const [repository, username] = url.split('/').reverse()
+      const [username, repository] = parseURL(url)
       const isValid = await save({ url, token, username, repository })
 
       if (isValid) {
@@ -130,7 +127,7 @@ function SettingsForm(): JSX.Element {
       </Box>
       <Box>
         <Label htmlFor="githubRepoURL" required>
-          Github repository URL
+          Public GitHub repository URL
         </Label>
         <Input
           aria-describedby="githubRepoURLText"
@@ -156,7 +153,11 @@ function SettingsForm(): JSX.Element {
           </Button>
         )}
         <Button variant="primary" onClick={submitHandler} loading={isLoading}>
-          {isLoading ? 'Validating configuration' : 'Update configuration'}
+          {isLoading
+            ? 'Validating configuration'
+            : isFirstTime
+              ? 'Save personal configuration'
+              : 'Update configuration'}
         </Button>
       </Flex>
     </Stack>

--- a/src/renderer/src/components/Viewer/Issues/IssueDetail/IssueDetailHeader.tsx
+++ b/src/renderer/src/components/Viewer/Issues/IssueDetail/IssueDetailHeader.tsx
@@ -6,14 +6,28 @@ import { Flex } from '@twilio-paste/core/flex'
 import { Heading } from '@twilio-paste/core/heading'
 import { Text } from '@twilio-paste/core/text'
 import { Tooltip } from '@twilio-paste/core/tooltip'
+import { Menu, MenuItem, useMenuState, MenuBadge } from '@twilio-paste/core/menu'
 import { GitIcon } from '@twilio-paste/icons/esm/GitIcon'
 import { LockIcon } from '@twilio-paste/icons/esm/LockIcon'
 import { SuccessIcon } from '@twilio-paste/icons/esm/SuccessIcon'
 import { ProcessInProgressIcon } from '@twilio-paste/icons/esm/ProcessInProgressIcon'
+import { DownloadIcon } from '@twilio-paste/icons/esm/DownloadIcon'
+import { useData } from '@renderer/providers'
+import { parseURL } from '@renderer/helpers'
 
 function IssueDetailTitle(props: { issue: Issue }): JSX.Element {
-  const { configuration } = useConfiguration()
+  const { configuration, swapURL } = useConfiguration()
+  const { repositoryURLs, loading } = useData()
+  const urlsMenu = useMenuState()
   const { issue } = props
+
+  const switchRepository = (url: string): void => {
+    if (url !== configuration?.url) {
+      swapURL(url)
+    }
+
+    urlsMenu.hide()
+  }
 
   return (
     <Box
@@ -25,20 +39,39 @@ function IssueDetailTitle(props: { issue: Issue }): JSX.Element {
     >
       <Flex padding={'space60'} vertical minHeight={'117px'} hAlignContent={'between'}>
         <Flex hAlignContent={'right'}>
-          <Tooltip text="Go to repo at github.com">
-            <Text fontWeight={'fontWeightBold'} as={'p'} marginBottom={'space40'}>
-              <Anchor href={configuration?.url || '#'} target="_blank">
-                <Flex>
-                  <Flex marginRight={'space10'}>
-                    <GitIcon decorative />
-                  </Flex>
+          <Box marginBottom={'space30'}>
+            <MenuBadge
+              {...urlsMenu}
+              disabled={loading}
+              i18nButtonLabel="Change account"
+              variant="decorative10"
+            >
+              <Tooltip text="Go to repo at github.com">
+                <Text fontWeight={'fontWeightBold'} as={'span'} color={'colorTextLink'}>
                   <Flex>
-                    {configuration?.username}/{configuration?.repository}
+                    <Flex marginRight={'space10'}>
+                      {loading ? <DownloadIcon decorative /> : <GitIcon decorative />}
+                    </Flex>
+                    <Flex>{parseURL(configuration!.url).join('/')}</Flex>
                   </Flex>
-                </Flex>
-              </Anchor>
-            </Text>
-          </Tooltip>
+                </Text>
+              </Tooltip>
+            </MenuBadge>
+            <Menu {...urlsMenu} aria-label="Repositories">
+              {repositoryURLs.map((url) => (
+                <MenuItem key={url} {...urlsMenu} onClick={() => switchRepository(url)}>
+                  <Flex hAlignContent={'between'} vAlignContent={'stretch'}>
+                    <Flex>{parseURL(url).join('/')}</Flex>
+                    <Flex marginLeft={'space50'}>
+                      <Anchor target="_blank" showExternal href={url}>
+                        Web
+                      </Anchor>
+                    </Flex>
+                  </Flex>
+                </MenuItem>
+              ))}
+            </Menu>
+          </Box>
         </Flex>
         <Flex grow vAlignContent={'bottom'}>
           <Heading as="h3" variant="heading20" marginBottom="space0">

--- a/src/renderer/src/components/Viewer/Issues/IssueList/index.tsx
+++ b/src/renderer/src/components/Viewer/Issues/IssueList/index.tsx
@@ -9,12 +9,13 @@ import { useEffect, useRef } from 'react'
 type IssueListProps = {
   issues: Issues
   loading?: boolean
+  selectedIssue?: Issue
   onSelectIssue: (issue: Issue) => void
   onScrollEnd: () => void
 }
 
 function IssueList(props: IssueListProps): JSX.Element {
-  const { issues, onSelectIssue, loading, onScrollEnd } = props
+  const { issues, onSelectIssue, loading, onScrollEnd, selectedIssue } = props
   const loaderRef = useRef<HTMLElement>(null)
 
   useEffect(() => {
@@ -61,8 +62,14 @@ function IssueList(props: IssueListProps): JSX.Element {
           paddingY={'space40'}
           cursor={'pointer'}
           transition={'border-left-width 0.3s'}
+          backgroundColor={
+            selectedIssue?.id === issue.id ? 'colorBackgroundPrimaryWeaker' : undefined
+          }
           _hover={{
-            backgroundColor: 'colorBackgroundBrandHighlightWeakest',
+            backgroundColor:
+              selectedIssue?.id === issue.id
+                ? 'colorBackgroundPrimaryWeaker'
+                : 'colorBackgroundPrimaryWeakest',
             borderLeftWidth: 'borderWidth40'
           }}
           onClick={() => onSelectIssue(issue)}

--- a/src/renderer/src/components/Viewer/Issues/IssueNav/index.tsx
+++ b/src/renderer/src/components/Viewer/Issues/IssueNav/index.tsx
@@ -46,7 +46,7 @@ function IssueNav(props: IssueNavProps): JSX.Element {
           </Heading>
           {unreadIssues > 0 && (
             <Flex marginLeft={'space40'}>
-              <Tooltip text={`View your ${unreadIssues} unread issues`} placement="auto">
+              <Tooltip text={`${unreadIssues} unread issues`} placement="auto">
                 <Badge as="span" size="small" variant="notification_counter">
                   {unreadIssues > 99 ? '+99' : unreadIssues}
                 </Badge>
@@ -72,6 +72,7 @@ function IssueNav(props: IssueNavProps): JSX.Element {
               name="filter"
               type="search"
               placeholder="Filter by keyword"
+              autoFocus
               onChange={(e): void => onSearch(e.target.value || '')}
               insertBefore={<SearchIcon decorative size="sizeIcon20" />}
             />

--- a/src/renderer/src/components/Viewer/Issues/index.tsx
+++ b/src/renderer/src/components/Viewer/Issues/index.tsx
@@ -1,4 +1,4 @@
-import { useData } from '@renderer/providers'
+import { useConfiguration, useData } from '@renderer/providers'
 import { Flex } from '@twilio-paste/core/flex'
 import IssueDetail from './IssueDetail'
 import IssueList from './IssueList'
@@ -10,6 +10,7 @@ function Issues(): JSX.Element {
   const [keyword, setKeyword] = useState('')
   const [selectedIssue, setSelectedIssue] = useState<Issue>()
   const { issues, read, loading, load } = useData()
+  const { configuration } = useConfiguration()
 
   const filteredIssues = useMemo(() => {
     if (issues && keyword && keyword.length >= 3) {
@@ -24,6 +25,10 @@ function Issues(): JSX.Element {
       read(selectedIssue)
     }
   }, [selectedIssue])
+
+  useEffect(() => {
+    setSelectedIssue(undefined)
+  }, [configuration?.url])
 
   useEffect(() => {
     if (Array.isArray(issues) && issues.length > 0 && !selectedIssue) {
@@ -43,6 +48,7 @@ function Issues(): JSX.Element {
         <IssueList
           issues={filteredIssues}
           onSelectIssue={setSelectedIssue}
+          selectedIssue={selectedIssue}
           loading={loading}
           onScrollEnd={load}
         />

--- a/src/renderer/src/helpers/index.ts
+++ b/src/renderer/src/helpers/index.ts
@@ -1,0 +1,29 @@
+/**
+ * Parses a valid URL to a GitHub repo and returns the repo owner and name.
+ * @param url A valid URL to a public Github repository. Can contain subfolders.
+ * @returns A tuple of string values featuring the GH owner username and the repo name.
+ */
+export const parseURL = (url: string): [string, string] => {
+  const urlObject = new URL(url)
+  const [, username, repository] = urlObject.pathname.split('/')
+
+  return [username, repository]
+}
+
+const tokenRegex = new RegExp(/^(gh[pous]_[a-zA-Z0-9]{36}|github_pat_[a-zA-Z0-9_]{22,38})$/)
+
+/**
+ * Validates if a given token payload is valid according to GitHub's PAT format.
+ * @param token The token to validate.
+ * @returns True if valid, false otherwise.
+ */
+export const isValidToken = (token: string): boolean => tokenRegex.test(token)
+
+const urlRegex = new RegExp(/^https:\/\/github\.com\/[a-zA-Z0-9_-]+\/[a-zA-Z0-9_-]+\/?$/)
+
+/**
+ * Validates if a given URL payload is valid according to GitHub's public repository URL schema.
+ * @param token The URL to validate.
+ * @returns True if valid, false otherwise.
+ */
+export const isValidURL = (url: string): boolean => urlRegex.test(url)


### PR DESCRIPTION
# feat: Extend support for multiple repositories

As per popular request, GitSquid now supports easy switching between configured repositories. As public repositories are added into the configuration, these will be persisted in the local app so they become available for selection, hence swapping the current issues snapshot with the already cached views.

<img width="1297" alt="Screenshot 2024-09-08 at 14 05 36" src="https://github.com/user-attachments/assets/0bb758a1-589d-49ce-b086-4f671360e9b7">

## Release notes:

- The repository link becomes a menu selector where users can botch switch to another repository or click on a link to the remote repo.
- Upon swapping repository, GitSquid will check for new issues in that repo.
- UX improvements on browsing the side menu
- This PR also refactors the way GitSquid handles records to remove flakiness when detecting whether the user has reached the end of the recordset.
