### PR TITLE
fix(plugin): ensure keys are generated at correct lifecycle step and add unit test for plugin

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -33,7 +33,6 @@ export default defineConfig(({ command }) => ({
         '**/preload/index.ts',
         '**/renderer/src/main.tsx',
         '**/electron.vite.config.ts',
-        'plugins/**',
         '**/types.ts',
         '.eslintrc.cjs'
       ]

--- a/plugins/index.spec.ts
+++ b/plugins/index.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { generateGitSquidKeysPlugin } from './index'
+import fs from 'fs'
+import path from 'path'
+
+const envPath = path.resolve(__dirname, '..', '.env')
+
+interface PluginWithConfig {
+  config: () => Promise<void>
+}
+
+function hasConfig(obj: unknown): obj is PluginWithConfig {
+  return (
+    !!obj &&
+    typeof obj === 'object' &&
+    'config' in obj &&
+    typeof (obj as PluginWithConfig).config === 'function'
+  )
+}
+
+describe('generateGitSquidKeysPlugin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    if (fs.existsSync(envPath)) fs.unlinkSync(envPath)
+  })
+
+  it('should always return a plugin object with config property', () => {
+    const pluginServe = generateGitSquidKeysPlugin('serve')
+    const pluginBuild = generateGitSquidKeysPlugin('build')
+    expect(pluginServe).toBeDefined()
+    expect(pluginBuild).toBeDefined()
+    expect(typeof pluginServe).toBe('object')
+    expect(typeof pluginBuild).toBe('object')
+    expect(pluginServe && 'config' in pluginServe).toBe(true)
+    expect(pluginBuild && 'config' in pluginBuild).toBe(true)
+  })
+
+  it('should write fixed dummy keys in development (serve)', async () => {
+    const plugin = generateGitSquidKeysPlugin('serve')
+
+    if (hasConfig(plugin)) {
+      await plugin.config()
+      const envContent = fs.readFileSync(envPath, 'utf8')
+      expect(envContent).toContain('SQUID_MAIN_KEY=395f46b7b0d78b2793e976c5326a379a')
+      expect(envContent).toContain('SQUID_MAIN_IV=0521b168b35255bf')
+    }
+  })
+
+  it('should write random keys in production (build)', async () => {
+    const plugin = generateGitSquidKeysPlugin('build')
+
+    if (hasConfig(plugin)) {
+      await plugin.config()
+      const envContent = fs.readFileSync(envPath, 'utf8')
+      // Should not match the dummy values
+      expect(envContent).not.toContain('395f46b7b0d78b2793e976c5326a379a')
+      expect(envContent).not.toContain('0521b168b35255bf')
+      // Should match expected env format
+      expect(envContent).toMatch(/SQUID_MAIN_KEY=\w{16,32}/)
+      expect(envContent).toMatch(/SQUID_MAIN_IV=\w{8,16}/)
+    }
+  })
+})

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -11,20 +11,19 @@ import type { PluginOption } from 'vite'
 export function generateGitSquidKeysPlugin(command: 'build' | 'serve'): PluginOption {
   return {
     name: 'generate-git-squid-keys-plugin',
-    apply: command,
-    buildEnd: async (): Promise<void> => {
+    config: async (): Promise<void> => {
       // Fixed unsafe dummy keys for development
       let key = '395f46b7b0d78b2793e976c5326a379a'
       let iv = '0521b168b35255bf'
 
       if (command === 'build') {
-        // Secret hashed keys for production environments generated once on build time
+        // Secret hashed keys for production environments
         key = crypto.randomBytes(32).toString('hex').substring(32)
         iv = crypto.randomBytes(16).toString('hex').substring(16)
       }
 
       const secrets = `SQUID_MAIN_KEY=${key}\nSQUID_MAIN_IV=${iv}`
-      writeFileSync(resolve(__dirname, '.env'), secrets)
+      writeFileSync(resolve(__dirname, '..', '.env'), secrets)
     }
   }
 }


### PR DESCRIPTION
- Refactor plugin to generate encryption keys at the correct Vite lifecycle step (config)
- Add unit test to validate key generation for both build and serve modes
- Fixes issues with .env file location and ensures test coverage for plugin behavior